### PR TITLE
Add a peer dependency for react-map-gl

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "prop-types": "^15.6.2",
     "viewport-mercator-project": "6.1.1"
   },
+  "peerDependencies": {
+    "react-map-gl": ">= 3.0.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",


### PR DESCRIPTION
Since react-map-gl-geocoder relies on react-map-gl, it should specify react-map-gl as a peer dependency.

I've picked version 3.0.0 as the minimum somewhat arbitrarily.